### PR TITLE
Add pack.mcmeta

### DIFF
--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+    "pack": {
+        "description": "Midnight Resources",
+        "pack_format": 3
+    }
+}


### PR DESCRIPTION
Currently, there is no `pack.mcmeta` specified in the mod, which causes the resources to be in a legacy format. A pack version of 3 means that the lang files *must* be in lower case, and other particular changes I may have forgotten, if there are. I cannot make a PR that fixes the name of the files, as it does not seem to register the changes.